### PR TITLE
Clean up mapConverter.py

### DIFF
--- a/map converter/mapConverter.py
+++ b/map converter/mapConverter.py
@@ -1,4 +1,8 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import os
+import sys
 
 #name = "Surf_01"
 #name = "Cror_01"
@@ -11,22 +15,50 @@ type = "predug"
 extension = ".map"
 #extension = ".ol"
 
+
+def getFileDetails(f):
+    name, extension = os.path.splitext(f)
+    normalizedName = name.lower()
+    fileType = None
+
+    if normalizedName.startswith("surf"):
+        fileType = "terrian"
+    elif normalizedName.startswith("cror"):
+        fileType = "cryore"
+    elif normalizedName.startswith("dugg"):
+        fileType = "predug"
+    elif extension.lower().endswith(".ol"):
+        fileType = "ol"
+
+    return {"name": name, "ext": extension, "type": fileType}
+
+
 def main():
-    #first ensure that there is a file to convert in the working directory 
-    if not (os.path.isfile(name + extension)):
-        print("Error: file named: {0} not found -> exiting".format(name + extension));
+    try:
+        inputFile = sys.argv[1]
+        inputFilePath = os.path.abspath(inputFile)
+    except IndexError:
+        print("Please give the input file as the script's argument.")
         return
-    
-    #delete conversion file if it already exists, as this file is going to be recreated
-    if os.path.isfile("{0}.js".format(name)):
-        os.remove("{0}.js".format(name))
-        print("File named: {0}.js already exists in this directory -> deleting file".format(name))
-    
-    #open map file and attempt to read it
-    with open(name + extension, "rb") as f:  
+
+    # First ensure that there is a file to convert in the working directory
+    if not os.path.isfile(inputFilePath):
+        print("Error: file named: {0} not found -> exiting".format(inputFile))
+        return
+
+    # Extract required details about the given file
+    details = getFileDetails(inputFile)
+
+    # Delete conversion file if it already exists, as this file is going to be recreated
+    if os.path.isfile("{0}.js".format(details["name"])):
+        os.remove("{0}.js".format(details["name"]))
+        print("File {0}.js already exists in this directory -> deleting file".format(details["name"]))
+
+    # Open map file and attempt to read it
+    with open(inputFilePath, "rb") as f:
         i = 0
         levelData = []
-        if (type == "terrain" or type == "cryore" or type == "predug"):   
+        if details["type"] in ("terrain", "cryore", "predug"):
             byte = f.read(1)
             mapWidth = None
             mapHeight = None
@@ -44,43 +76,43 @@ def main():
                     i = 0
                     firstRun = False
                 byte = f.read(1)
-        elif (type == "ol"):
+        elif details["type"] == "ol":
             for line in f:
                 i += 1
                 if i == 1:
                     levelData.append("object = {")
                 else:
                     if line == b'\r\n':
-                        continue;
-                    levelData.append(str(line.decode('ascii')).replace(" ",":").replace("\t",":").lstrip(":").strip()) 
+                        continue
+                    levelData.append(str(line.decode('ascii')).replace(" ",":").replace("\t",":").lstrip(":").strip())
                     breakPos = levelData[-1].find(":")
                     if levelData[-1][breakPos+1].isalpha():
                         levelData[-1] = levelData[-1][:breakPos+1] + '"' + levelData[-1][breakPos+1:] + '"'
                     if (levelData[-2][-1] != "{") and (levelData[-1][-1] != "}"):
                         levelData[-2] += ","
-                    
-            
-    print("Data successfully read from file: {0}".format(name + extension))
-    
-    if (type == "terrain" or type == "cryore" or type == "predug"):
+
+
+    print("Data successfully read from file: {0}".format(inputFile))
+
+    if details["type"] in ("terrain", "cryore", "predug"):
         print("Map dimensions: {0}x{1} units".format(str(mapWidth),str(mapHeight)))
-            
+
         #throw out the first row of bytes, as its data is not part of the map
         del levelData[0]
         #throw out the last row, as it is just an empty list
         del levelData[-1]
-        
+
         #remove every odd byte, as they are always going to be 0
         for i in range(len(levelData)):
             del levelData[i][1::2]
-        
+
     #write the remaining contents of levelData to a new JS file for use by the game engine
     with open("{0}.js".format(name),'a') as file:
-        if (type == "terrain" or type == "cryore" or type == "predug"):
+        if details["type"] in ("terrain", "cryore", "predug"):
             file.write("object = {{ \nlevel: [\n{0}\n]\n}};".format(",\n".join(map(str,levelData))))
-        elif (type == "ol"):
+        elif details["type"] == "ol":
             file.write("{0};".format("\n".join(map(str,levelData))))
-        
+
     print("Successfully wrote level data to file: {0}.js".format(name))
 
 if __name__ == "__main__":

--- a/map converter/mapConverter.py
+++ b/map converter/mapConverter.py
@@ -70,7 +70,7 @@ def main():
                     mapHeight = int(byte[0])
                 if (
                     ((firstRun) and (i == 16)) or
-                    ((not firstRun) and (i == mapWidth*2))
+                    ((not firstRun) and (i == mapWidth * 2))
                 ):
                     levelData.append([])
                     i = 0


### PR DESCRIPTION
This PR cleans up the map converter in a number of ways.
- Remove the hard-coded filename, extension, and type values and replaced it with a helper function to determine  such information.
- File input is now a script argument (you should also be able to drag and drop a file onto it)
- Use a tuple to check multiple types instead of direct comparisons (see [my tutorial](https://triangle717.wordpress.com/2014/12/23/python-comparing-against-multiple-items/) on this topic)
- Various cleanup and optimizations
- Revised script formatting to make it more readable and conform to PEP 8 (see also: [flake8](https://pypi.python.org/pypi/flake8), http://pep8online.com)

All this is 100% untested. It should all work as before, but you may want to check first. :wink:
