### PR TITLE
Remove tasksUnavailable

### DIFF
--- a/classes/Raider.js
+++ b/classes/Raider.js
@@ -1,11 +1,12 @@
 makeChild("Raider","RygameObject");
 Raider.prototype.chooseClosestBuilding = function(buildingType,resourceTypeNeeded) {
+	var buildingList = (buildingType == "building site" ? buildingSites : buildings);
 	destinationSites = [];
 	destinationSite = null;
-	for (var i = 0; i < buildings.length; i++) { //compile all buildings of type buildingType, then find closest one
-		if (buildings[i].type == buildingType && buildings[i].touched == true) { //if its not touched yet it is not pathable so dont choose it (this case should be impossible though because buildings that start out in Fog are not added to the buildings list until they are touched)
-			if (resourceTypeNeeded == null || buildingSites[i].resourceNeeded(resourceTypeNeeded)) { //if we're looking to place a resource, check if the building site needs it
-				destinationSites.push(buildings[i]);
+	for (var i = 0; i < buildingList.length; i++) { //compile all buildings of type buildingType, then find closest one
+		if (buildingList[i].type == buildingType && buildingList[i].touched == true) { //if its not touched yet it is not pathable so dont choose it (this case should be impossible though because buildings that start out in Fog are not added to the buildings list until they are touched)
+			if (resourceTypeNeeded == null || buildingList[i].resourceNeeded(resourceTypeNeeded)) { //if we're looking to place a resource, check if the building site needs it
+				destinationSites.push(buildingList[i]);
 			}
 		}
 	}
@@ -465,6 +466,9 @@ Raider.prototype.update = function() {
 								if (newPath != null) {
 									this.currentPath = newPath;
 									this.busy = false;
+									if (this.currentObjective.type == "building site") {
+										this.currentTask = this.currentObjective;
+									}
 								}
 								else {
 									this.currentObjective = this.currentTask;

--- a/classes/Raider.js
+++ b/classes/Raider.js
@@ -84,9 +84,11 @@ Raider.prototype.checkChooseCloserEquivalentResource = function(removeCurrentTas
 };
 
 //set current task, objective, and path, and remove from tasksAvailable
-Raider.prototype.setTask = function(taskIndex, path, initialObjective = null) {
+Raider.prototype.setTask = function(taskIndex, path, initialObjective, keepTask) {
 	this.currentTask = tasksAvailable[taskIndex];
-	tasksAvailable.splice(taskIndex,1);
+	if (!keepTask) {
+		tasksAvailable.splice(taskIndex,1);	
+	}
 	if (initialObjective != null) {
 		this.currentObjective = initialObjective;
 		this.currentPath = findClosestStartPath(this,calculatePath(terrain,this.space,typeof initialObjective.space == "undefined" ? initialObjective: initialObjective.space,true));
@@ -175,7 +177,7 @@ Raider.prototype.checkSetTask = function(i,mustBeHighPriority,calculatedPath) {
 					this.currentObjectiveResourceType = dedicatedResourceTypes[r];
 					reservedResources[this.currentObjectiveResourceType]++;
 					this.reservingResource = true;
-					this.setTask(i,newPath,destinationSite);
+					this.setTask(i,newPath,destinationSite,true);
 					return true;
 				}
 			}

--- a/classes/Raider.js
+++ b/classes/Raider.js
@@ -107,7 +107,7 @@ Raider.prototype.canPerformTask = function(task,ignoreContents) {
 				var newIndex = tasksAvailable.indexOf(task.contains.objectList[i]);
 				//make sure this task is available before proceeding
 				if (newIndex != -1) {
-					return canPerformTask(task.contains.objectList[i],true);
+					return this.canPerformTask(task.contains.objectList[i],true);
 				}
 			}
 		}
@@ -236,8 +236,9 @@ Raider.prototype.update = function() {
 	if ((selection.indexOf(this) != -1) && (this.currentTask == null)) { //don't start a new task if currently selected unless instructed to
 		return;
 	}
-	
-	this.checkChooseNewTask();
+	if (this.currentTask == null) {
+		this.checkChooseNewTask();
+	}
 	if (this.currentTask == null) {
 		return;
 	}

--- a/classes/Raider.js
+++ b/classes/Raider.js
@@ -149,6 +149,11 @@ Raider.prototype.canPerformTask = function(task,ignoreContents) {
 //attempt to set task index i, if it passes the checks
 Raider.prototype.checkSetTask = function(i,mustBeHighPriority,calculatedPath) {
 	//TODO: raiders will select the first high priority task this way, rather than the nearest one. Should be fixed when implementing automatic task priority order.
+	//if this task index is invalid, return now
+	if (i == -1) {
+		return false;
+	}
+	
 	//skip any tasks that cannot be performed automatically, unless they are high priority
 	if (tasksAvailable[i].taskPriority == 1 || (tasksAutomated[taskType(tasksAvailable[i])] && (mustBeHighPriority != true))) {
 		var newPath = calculatedPath; //if we already calculated a path, don't bother calculating it again

--- a/classes/Raider.js
+++ b/classes/Raider.js
@@ -148,12 +148,9 @@ Raider.prototype.canPerformTask = function(task,ignoreContents) {
 
 //attempt to set task index i, if it passes the checks
 Raider.prototype.checkSetTask = function(i,mustBeHighPriority,calculatedPath) {
-	//skip any tasks that cannot be performed automatically (though these should most likely not be high priority regardless) 
-	if (!tasksAutomated[taskType(tasksAvailable[i])]) {
-		return false;
-	}
 	//TODO: raiders will select the first high priority task this way, rather than the nearest one. Should be fixed when implementing automatic task priority order.
-	if (tasksAvailable[i].taskPriority == 1 || (mustBeHighPriority != true)) {
+	//skip any tasks that cannot be performed automatically, unless they are high priority
+	if (tasksAvailable[i].taskPriority == 1 || (tasksAutomated[taskType(tasksAvailable[i])] && (mustBeHighPriority != true))) {
 		var newPath = calculatedPath; //if we already calculated a path, don't bother calculating it again
 		if (newPath == null) {
 			newPath = findClosestStartPath(this,calculatePath(terrain,this.space,typeof tasksAvailable[i].space == "undefined" ? tasksAvailable[i]: tasksAvailable[i].space,true));

--- a/classes/Space.js
+++ b/classes/Space.js
@@ -393,31 +393,7 @@ Space.prototype.setTypeProperties = function(type,doNotChangeImage,rubbleContain
 			}
 			else { //this case should never be possible
 				console.log("WARNING: BUILDING TRIED TO ADD ITSELF TO BUILDINGS LIST, BUT WAS ALREADY THERE");
-			}
-
-			var testTask;
-			for (var k = 0; k < tasksUnavailable.length; k++) { //this chunk of code is copied from Raider update method
-				testTask = tasksUnavailable.objectList[k];
-				if (taskType(testTask) == "build") { //&& testTask.resourceNeeded(this.holding.type)) {
-					//if (testTask.resourceNeeded()) { //TODO: REPLACE THIS LINE WITH A CHECK IF ONE OF THE RESOURCES NEEDED IS CURRENTLY IN THE STASH, AS OTHERWISE ADDING THE BUILD TASK TO TASKSAVAILABLE IS POINTLESS, AS IT WILL BE SENT BACK TO TASKSUNAVAILABLE WHEN A RAIDER TRIES TO TAKE UP THE TASK
-					
-					//the below chunk of code is copied from a different part of Raider update method
-					var dedicatedResourceTypes = Object.getOwnPropertyNames(testTask.dedicatedResources); //TODO: THIS IS COPIED FROM THE RESOURCENEEDED METHOD, AND SHOULD BE PUT IN ITS OWN SUBMETHOD AS IT IS REPEAT CODE
-					for (var i = 0; i < dedicatedResourceTypes.length; i++) {
-						if (testTask.dedicatedResources[dedicatedResourceTypes[i]] < testTask.requiredResources[dedicatedResourceTypes[i]]) {
-							//console.log("stuck at this point");
-							if (resourceAvailable(dedicatedResourceTypes[i])) {					
-								tasksAvailable.push(testTask);
-								tasksUnavailable.remove(tasksUnavailable.objectList[k]); //use remove rather than splicing to update object groupsContained
-								break;
-							}
-						}					
-						
-					}
-					//continue //TODO: DECIDE WHETHER OR NOT IT IS OK FOR US TO POTENTIALLY REENABLE MORE THAN ONE BUILDING SITE WHEN WE MAY ONLY HAVE 1 OF A REQUIRED RESOURCE TYPE
-				}
-			}
-			
+			}			
 		}
 		
 	}

--- a/classes/Space.js
+++ b/classes/Space.js
@@ -500,6 +500,11 @@ Space.prototype.updatePlacedResources = function(resourceType) {
 	}
 	if (this.allResourcesPlaced()) {
 		//console.log("all resources placed");
+		//remove this from the list of available tasks once it is finished being built
+		var taskIndex = tasksAvailable.indexOf(this);
+		if (taskIndex != -1) {
+			tasksAvailable.splice(taskIndex,1);
+		}
 		this.setTypeProperties(this.buildingSiteType);
 		
 		var index = buildingSites.indexOf(this);

--- a/rockRaiders.js
+++ b/rockRaiders.js
@@ -504,6 +504,10 @@ function checkUpdateSelectionType() {
 	}
 	if (selection[0] instanceof Space) {
 		selectionType = selection[0].touched == true ? selection[0].type : "Hidden";
+		//tileSelectedGraphic.drawDepth = 5000; //put tile selection graphic between space and collectable (can't do this without engine change, as this variable is used once on object creation to determine render order)
+	}
+	if (selection[0] instanceof Collectable) {
+		//tileSelectedGraphic.drawDepth = 5; //put tile selection graphic in fromt of collectable
 	}
 }
 

--- a/rockRaiders.js
+++ b/rockRaiders.js
@@ -145,7 +145,9 @@ function calculatePath(terrain,startSpace,goalSpace,returnAllSolutions,raider) {
 	}
 	
 	//initialize starting variables
-	goalSpace.parents = [];
+	if (goalSpace != null) {
+		goalSpace.parents = [];	
+	}
 	
 	startSpace.startDistance = 0;
 	startSpace.parents = [];

--- a/rockRaiders.js
+++ b/rockRaiders.js
@@ -134,14 +134,14 @@ function findClosestStartPath(startObject,paths) {
 	return paths[closestIndex];
 }
 
-function calculatePath(terrain,startSpace,goalSpace,returnAllSolutions) { 
+function calculatePath(terrain,startSpace,goalSpace,returnAllSolutions,raider) { 
 	/*find shortest path from startSpace to a space satisfying desiredProperty (note: path goes from end to start, not from start to end)*/
 	//if startSpace meets the desired property, return it without doing any further calculations
-	if (startSpace == goalSpace) {
+	if (startSpace == goalSpace || (goalSpace == null && raider.canPerformTask(startSpace))) {
 		if (!returnAllSolutions) {
-			return [goalSpace];
+			return [startSpace];
 		}
-		return [[goalSpace]];
+		return [[startSpace]];
 	}
 	
 	//initialize starting variables
@@ -175,7 +175,8 @@ function calculatePath(terrain,startSpace,goalSpace,returnAllSolutions) {
 			
 			//check this here so that the algorithm is a little bit faster, but also so that paths to non-walkable terrain pieces (such as for drilling) will work
 			//if the newSpace is a goal, find a path back to startSpace (or all equal paths if returnAllSolutions is True)
-			if (newSpace == goalSpace) {
+			if (newSpace == goalSpace || (goalSpace == null && raider.canPerformTask(newSpace))) {
+				goalSpace = newSpace;
 				newSpace.parents = [currentSpace]; //start the path with currentSpace and work our way back
 				pathsFound = [[newSpace]];
 				

--- a/rockRaiders.js
+++ b/rockRaiders.js
@@ -510,10 +510,12 @@ function checkUpdateSelectionType() {
 	}
 	if (selection[0] instanceof Space) {
 		selectionType = selection[0].touched == true ? selection[0].type : "Hidden";
-		//tileSelectedGraphic.drawDepth = 5000; //put tile selection graphic between space and collectable (can't do this without engine change, as this variable is used once on object creation to determine render order)
+		tileSelectedGraphic.drawDepth = 5000; //put tile selection graphic between space and collectable
+		GameManager.refreshObject(tileSelectedGraphic);
 	}
 	if (selection[0] instanceof Collectable) {
-		//tileSelectedGraphic.drawDepth = 5; //put tile selection graphic in fromt of collectable
+		tileSelectedGraphic.drawDepth = 5; //put tile selection graphic in fromt of collectable
+		GameManager.refreshObject(tileSelectedGraphic);
 	}
 }
 

--- a/rockRaiders.js
+++ b/rockRaiders.js
@@ -374,19 +374,25 @@ function loadLevelData(name) {
 	    	var headingDir = Math.round(olObject.heading); //don't do an int conversion here as we need this to be exactly one of 4 values
 	    	if (headingDir == 0) {
 	    		powerPathSpace = adjacentSpace(terrain,currentSpace.listX,currentSpace.listY,"up");
+		    	currentSpace.headingAngle = Math.PI;//use an angle variable separate from drawAngle so that the object does not draw a rotated image when in the fog
 	    	}
 	    	else if (headingDir == 90) {
 	    		powerPathSpace = adjacentSpace(terrain,currentSpace.listX,currentSpace.listY,"right");
+		    	currentSpace.headingAngle = -.5*Math.PI;//use an angle variable separate from drawAngle so that the object does not draw a rotated image when in the fog
 	    	}
 	    	else if (headingDir == 180) {
 	    		powerPathSpace = adjacentSpace(terrain,currentSpace.listX,currentSpace.listY,"down");
+		    	currentSpace.headingAngle = 0;//use an angle variable separate from drawAngle so that the object does not draw a rotated image when in the fog
 	    	}
 	    	else if (headingDir == 270) {
 	    		powerPathSpace = adjacentSpace(terrain,currentSpace.listX,currentSpace.listY,"left");
+		    	currentSpace.headingAngle = .5*Math.PI;//use an angle variable separate from drawAngle so that the object does not draw a rotated image when in the fog
+	    	}
+	    	if (currentSpace.touched) { //set drawAngle to headingAngle now if this space isn't in the fog to start
+	    		currentSpace.drawAngle = currentSpace.headingAngle;
 	    	}
 	    	currentSpace.powerPathSpace = powerPathSpace;
 	    	currentSpace.powerPathSpace.setTypeProperties("power path");
-	    	currentSpace.headingAngle = (headingDir-180)/180*Math.PI; //use an angle variable separate from drawAngle so that the object does not draw a rotated image when in the fog
 	    }
 	}
 }

--- a/rockRaiders.js
+++ b/rockRaiders.js
@@ -514,7 +514,7 @@ function checkUpdateSelectionType() {
 		GameManager.refreshObject(tileSelectedGraphic);
 	}
 	if (selection[0] instanceof Collectable) {
-		tileSelectedGraphic.drawDepth = 5; //put tile selection graphic in fromt of collectable
+		tileSelectedGraphic.drawDepth = 5; //put tile selection graphic in front of collectable
 		GameManager.refreshObject(tileSelectedGraphic);
 	}
 }

--- a/rockRaiders.js
+++ b/rockRaiders.js
@@ -1408,6 +1408,7 @@ function initGlobals() {
 			"collect":true,
 			"drill":false,
 			"build":true,
+			"walk":true
 	};
 	toolsRequired = { //dict of task type to required tool
 			"sweep":"shovel",

--- a/rygame.js
+++ b/rygame.js
@@ -431,6 +431,13 @@ GameManagerInternal.prototype.removeObject = function(object) { //TODO still nee
 	this.renderOrderedCompleteObjectList.splice(this.renderOrderedCompleteObjectList.indexOf(object),1); 
 	this.updateOrderedCompleteObjectList.splice(this.updateOrderedCompleteObjectList.indexOf(object),1); 	
 };
+
+//remove and re-insert object in order to update render and update depth
+GameManagerInternal.prototype.refreshObject = function(object) {
+	this.removeObject(object);
+	this.addObject(object);
+};
+
 GameManagerInternal.prototype.addLayer = function(layer) {
 	this.completeLayerList.splice(binarySearch(this.completeLayerList,layer,"drawDepth"),0,layer); 
 };


### PR DESCRIPTION
the tasksUnavailable list has been completely removed. All references to this list have been tweaked as necessary. Raider automatic task selection has been rewritten to always find the closest task via a breadth-first search, rather than shuffling tasks between tasksAvailable and tasksUnavailable. Various subsequent bugs with the raider AI have been fixed.